### PR TITLE
Add more Meta UAs, adjust Messenger regex, and add Threads

### DIFF
--- a/.changeset/chilled-onions-scream.md
+++ b/.changeset/chilled-onions-scream.md
@@ -1,0 +1,7 @@
+---
+"inapp-spy": minor
+---
+
+- Add recent Meta UAs to tests
+- Add `threads` appKey
+- Adjust messenger regex for newer UAs

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ const { isInApp, appKey, appName } = InAppSpy();
 
   appKey: "messenger" |
     "facebook" |
+    "threads" |
     "twitter" |
     "wechat" |
     "instagram" |

--- a/src/regexAppName.ts
+++ b/src/regexAppName.ts
@@ -1,6 +1,7 @@
 export const appNameRegExps = {
   messenger: {
-    regex: /(\bFB[\w_]+\/(Messenger))|(\s\s\[FB_IAB)/i, // newer UAs on Android harder to detect - the two spaces is experimental however if UA changes will get picked up by facebook regex
+    regex:
+      /(\bFB[\w_]+\/(Messenger))|(^(?!.*\buseragents)(?!.*\bIABMV).*FB_IAB.*)/i, // Experimental for newer UAs - don't have `"useragents:" or end in "FB_IAB"
     name: "Facebook Messenger",
     // version: /FBAV\/(\d+)/, -- stubbing in version testing if we decide to add that for meta products
   },
@@ -27,7 +28,7 @@ export const appNameRegExps = {
     // version: /Instagram\s+\/(\d+)/i,
   },
   threads: {
-    regex: /Barcelona/i,
+    regex: /\bBarcelona/i,
     name: "Threads",
     // version: /Barcelona\s+\/(\d+)/i,
   },

--- a/src/regexAppName.ts
+++ b/src/regexAppName.ts
@@ -1,6 +1,6 @@
 export const appNameRegExps = {
   messenger: {
-    regex: /\bFB[\w_]+\/(Messenger|MESSENGER)/,
+    regex: /(\bFB[\w_]+\/(Messenger))|(\s\s\[FB_IAB)/i, // newer UAs on Android harder to detect - the two spaces is experimental however if UA changes will get picked up by facebook regex
     name: "Facebook Messenger",
   },
   facebook: {
@@ -22,6 +22,10 @@ export const appNameRegExps = {
   instagram: {
     regex: /\bInstagram/i,
     name: "Instagram",
+  },
+  threads: {
+    regex: /Barcelona/i,
+    name: "Threads",
   },
   tiktok: {
     regex: /musical_ly|Bytedance/i,

--- a/src/regexAppName.ts
+++ b/src/regexAppName.ts
@@ -1,19 +1,17 @@
+// NOTE: Consider getting the versions of known in-app browsers
 export const appNameRegExps = {
   messenger: {
     regex:
       /(\bFB[\w_]+\/(Messenger))|(^(?!.*\buseragents)(?!.*\bIABMV).*(FB_IAB|FBAN).*)/i, // Experimental for newer UAs - don't have `"useragents:" or end in "IABMV"
     name: "Facebook Messenger",
-    // version: /FBAV\/(\d+)/, -- stubbing in version testing if we decide to add that for meta products
   },
   instagram: {
     regex: /\bInstagram/i,
     name: "Instagram",
-    // version: /Instagram\s+\/(\d+)/i,
   },
   facebook: {
     regex: /\bFB[\w_]+\//,
     name: "Facebook",
-    // version: /FBAV\/(\d+)/,
   },
   twitter: {
     regex: /\bTwitter/i,
@@ -30,7 +28,6 @@ export const appNameRegExps = {
   threads: {
     regex: /\bBarcelona/i,
     name: "Threads",
-    // version: /Barcelona\s+\/(\d+)/i,
   },
   tiktok: {
     regex: /musical_ly|Bytedance/i,

--- a/src/regexAppName.ts
+++ b/src/regexAppName.ts
@@ -2,10 +2,12 @@ export const appNameRegExps = {
   messenger: {
     regex: /(\bFB[\w_]+\/(Messenger))|(\s\s\[FB_IAB)/i, // newer UAs on Android harder to detect - the two spaces is experimental however if UA changes will get picked up by facebook regex
     name: "Facebook Messenger",
+    // version: /FBAV\/(\d+)/, -- stubbing in version testing if we decide to add that for meta products
   },
   facebook: {
     regex: /\bFB[\w_]+\//,
     name: "Facebook",
+    // version: /FBAV\/(\d+)/,
   },
   twitter: {
     regex: /\bTwitter/i,
@@ -22,10 +24,12 @@ export const appNameRegExps = {
   instagram: {
     regex: /\bInstagram/i,
     name: "Instagram",
+    // version: /Instagram\s+\/(\d+)/i,
   },
   threads: {
     regex: /Barcelona/i,
     name: "Threads",
+    // version: /Barcelona\s+\/(\d+)/i,
   },
   tiktok: {
     regex: /musical_ly|Bytedance/i,

--- a/src/regexAppName.ts
+++ b/src/regexAppName.ts
@@ -1,9 +1,14 @@
 export const appNameRegExps = {
   messenger: {
     regex:
-      /(\bFB[\w_]+\/(Messenger))|(^(?!.*\buseragents)(?!.*\bIABMV).*FB_IAB.*)/i, // Experimental for newer UAs - don't have `"useragents:" or end in "FB_IAB"
+      /(\bFB[\w_]+\/(Messenger))|(^(?!.*\buseragents)(?!.*\bIABMV).*(FB_IAB|FBAN).*)/i, // Experimental for newer UAs - don't have `"useragents:" or end in "IABMV"
     name: "Facebook Messenger",
     // version: /FBAV\/(\d+)/, -- stubbing in version testing if we decide to add that for meta products
+  },
+  instagram: {
+    regex: /\bInstagram/i,
+    name: "Instagram",
+    // version: /Instagram\s+\/(\d+)/i,
   },
   facebook: {
     regex: /\bFB[\w_]+\//,
@@ -21,11 +26,6 @@ export const appNameRegExps = {
   wechat: {
     regex: /\bMicroMessenger\//i,
     name: "WeChat",
-  },
-  instagram: {
-    regex: /\bInstagram/i,
-    name: "Instagram",
-    // version: /Instagram\s+\/(\d+)/i,
   },
   threads: {
     regex: /\bBarcelona/i,

--- a/src/tests/mobile.ts
+++ b/src/tests/mobile.ts
@@ -249,6 +249,7 @@ export const MOBILE: DeviceObj = {
         {
           useragents: [
             "Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/AP2A.240905.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/130.0.6723.58 Mobile Safari/537.36  [FB_IAB/FB4A;FBAV/481.1.0.74.109;]",
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/AP2A.240905.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/130.0.6723.58 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/482.0.0.71.108;]",
           ],
         },
       ],

--- a/src/tests/mobile.ts
+++ b/src/tests/mobile.ts
@@ -227,6 +227,34 @@ export const MOBILE: DeviceObj = {
   },
   PIXEL: {
     inapp: {
+      FACEBOOK: [
+        {
+          useragents: [
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/AP2A.240905.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/130.0.6723.83 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/488.0.0.62.79;IABMV/1;]",
+          ],
+        },
+      ],
+      MESSENGER: [
+        {
+          useragents: [
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/AP2A.240905.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/130.0.6723.58 Mobile Safari/537.36  [FB_IAB/FB4A;FBAV/481.1.0.74.109;]",
+          ],
+        },
+      ],
+      INSTAGRAM: [
+        {
+          useragents: [
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/AP2A.240905.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/130.0.6723.58 Mobile Safari/537.36 Instagram 355.1.0.44.103 Android (34/14; 420dpi; 1080x2205; Google/google; Pixel 8; shiba; shiba; en_US; 658190016)",
+          ],
+        },
+      ],
+      THREADS: [
+        {
+          useragents: [
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/AP2A.240905.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/130.0.6723.58 Mobile Safari/537.36 Barcelona 355.0.0.39.109 Android (34/14; 420dpi; 1080x2205; Google/google; Pixel 8; shiba; shiba; en_US; 657318936)",
+          ],
+        },
+      ],
       TIKTOK: [
         {
           useragents: [

--- a/src/tests/mobile.ts
+++ b/src/tests/mobile.ts
@@ -225,6 +225,17 @@ export const MOBILE: DeviceObj = {
       ],
     },
   },
+  XIAOMI: {
+    inapp: {
+      INSTAGRAM: [
+        {
+          useragents: [
+            "Mozilla/5.0 (Linux; Android 11; Mi A3 Build/RKQ1.200903.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.14 Mobile Safari/537.36 Instagram 355.0.0.37.103 Android (30/11; 320dpi; 720x1411; Xiaomi; Mi A3; laurel_sprout; qcom; pt_BR; 657300861)",
+          ],
+        },
+      ],
+    },
+  },
   PIXEL: {
     inapp: {
       FACEBOOK: [

--- a/src/tests/mobile.ts
+++ b/src/tests/mobile.ts
@@ -35,6 +35,7 @@ export const MOBILE: DeviceObj = {
         {
           useragents: [
             "Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Mobile/14D27 {useragents: [FBAN/MessengerForiOS;FBAV/117.0.0.36.70;FBBV/57539258;FBDV/iPhone7,2;FBMD/iPhone;FBSN/iOS;FBSV/10.2.1;FBSS/2;FBCR/&#20013-&#33775-&#38651-&#20449-;FBID/phone;FBLC/zh_TW;FBOP/5;FBRV/0]",
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBAV/482.2.0.68.110;FBBV/658316928;FBDV/iPhone12,8;FBMD/iPhone;FBSN/iOS;FBSV/18.1;FBSS/2;FBCR/;FBID/phone;FBLC/en_US;FBOP/80]",
           ],
           ...appleTouchWindow,
         },
@@ -43,6 +44,7 @@ export const MOBILE: DeviceObj = {
         {
           useragents: [
             "Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Mobile/14D27 {useragents: [FBAN/FBIOS;FBAV/93.0.0.49.65;FBBV/58440824;FBDV/iPhone7,2;FBMD/iPhone;FBSN/iOS;FBSV/10.2.1;FBSS/2;FBCR/&#20013-&#33775-&#38651-&#20449-;FBID/phone;FBLC/zh_TW;FBOP/5;FBRV/0]",
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/22B83 [FBAN/FBIOS;FBAV/488.0.0.68.101;FBBV/658219612;FBDV/iPhone12,8;FBMD/iPhone;FBSN/iOS;FBSV/18.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0;IABMV/1]",
           ],
           ...appleTouchWindow,
         },
@@ -67,6 +69,7 @@ export const MOBILE: DeviceObj = {
         {
           useragents: [
             "Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Mobile/14D27 Instagram 10.21.0 (iPhone7,2; iOS 10_2_1; zh-Hant_JP; zh-Hant-JP; scale=2.00; gamut=normal; 750x1334)",
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/22B83 Instagram 354.0.0.29.90 (iPhone12,8; iOS 18_1; en_US; en; scale=2.00; 750x1334; 654111336; IABMV/1)",
           ],
           ...appleTouchWindow,
         },


### PR DESCRIPTION
# What this does

- Adds detection for threads
- Adds more Android Meta UAs
- Adds experimental new detection for Facebook Messenger (older UAs easier to detect and if it fails it will fall back to Facebook detection)

Related:
https://github.com/shalanah/inapp-debugger/issues/11