### PR TITLE
Add back UA as optional param

### DIFF
--- a/.changeset/tasty-wolves-worry.md
+++ b/.changeset/tasty-wolves-worry.md
@@ -1,0 +1,5 @@
+---
+"inapp-spy": minor
+---
+
+Add ua optional param, update Readme with CDN

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ yarn add inapp-spy
 npm install inapp-spy
 ```
 
+Or via CDN
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/inapp-spy@4.2.1/dist/index.global.min.js"></script>
+```
+
 # Code Examples
 
 ## Basic
@@ -57,7 +63,9 @@ const { isInApp, appKey, appName } = InAppSpy();
 
 ```ts
 InAppSpy({
-  // To skip a specific appKey from detection
+  // User agent for server side - leave blank for better client in-app detection
+  ua?: string;
+  // Skip a specific appKey from detection
   skip?: {
     appKey: AppKey; // "messenger" | "facebook" etc
     platform?: "apple" | "android"; // use undefined for all platforms or leave blank

--- a/src/detectionCustom.ts
+++ b/src/detectionCustom.ts
@@ -7,6 +7,7 @@ export const appNameCustom = {
 } as const;
 
 export const getDetectionCustom = () => {
+  if (typeof window === "undefined") return; // Skip if not in browser ie: server-side and only ua given
   if (getIsTelegram()) return "telegram";
   return;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { getSFSVCExperimental } from "./detectionSFSVC";
 
 const InAppSpy = (
   options: {
+    ua?: string;
     skip?: Skip;
   } = {}
 ): {
@@ -17,8 +18,8 @@ const InAppSpy = (
   appName: AppName;
   skipped: boolean; // a helper to know if we successfully skipped the app
 } => {
-  const { skip } = options;
-  const userAgent = getUA();
+  const { skip, ua = "" } = options;
+  const userAgent = ua || getUA();
 
   // No userAgent
   if (!userAgent)


### PR DESCRIPTION
For server-side detection adding back ua as an optional param.

Most detection should still work with ua passed in server side except for Telegram and SFSVC because those rely on the window being present.

Also documents CDN availability. #39 