### PR TITLE
Closes #44 - v4.2.0 breaks compatibility with webpack

### DIFF
--- a/.changeset/few-schools-give.md
+++ b/.changeset/few-schools-give.md
@@ -1,0 +1,5 @@
+---
+"inapp-spy": minor
+---
+
+Removes browser field from package, adds explicit bundles for jsdelivr, unpkg, and adds exports for global

--- a/package.json
+++ b/package.json
@@ -27,17 +27,20 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.global.js",
   "files": [
     "/dist"
   ],
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "browser": "./dist/index.global.js"
+      "require": "./dist/index.js"
+    },
+    "./global": {
+      "default": "./dist/index.global.js"
     }
   },
+  "jsdelivr": "dist/index.global.js",
+  "unpkg": "dist/index.global.js",
   "scripts": {
     "build": "tsup",
     "test": "jest --coverage ./src",


### PR DESCRIPTION
- Removes browser field in package (as field and in exports)
- Adds explicit `jsdelivr` and `unpkg` fields to package
- Adds `./global` to explorts
- Closes #44 