### PR TITLE
Remove global attachment to window unless using global file

### DIFF
--- a/.changeset/clever-carrots-complain.md
+++ b/.changeset/clever-carrots-complain.md
@@ -1,0 +1,5 @@
+---
+"inapp-spy": major
+---
+
+Fix global access to InAppSpy for non-global import/requires

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { appNameRegExps, getAppKey } from "./regexAppName";
 import { inappRegex } from "./regexInApp";
 import { getSFSVCExperimental } from "./detectionSFSVC";
 
+declare const __GLOBAL__: boolean;
+
 const InAppSpy = (
   options: {
     ua?: string;
@@ -71,8 +73,8 @@ const InAppSpy = (
 export const SFSVCExperimental = getSFSVCExperimental;
 export default InAppSpy;
 
-// For our global exports
-if (typeof window !== "undefined") {
+// For our global exports – only attach if __GLOBAL__ is true.
+if (typeof window !== "undefined" && __GLOBAL__) {
   (window as any).InAppSpy = InAppSpy; // Default export
   (window as any).SFSVCExperimental = SFSVCExperimental; // Named export
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ const InAppSpy = (
 export const SFSVCExperimental = getSFSVCExperimental;
 export default InAppSpy;
 
-// For our global exports – only attach if __GLOBAL__ is true.
+// Only attach if UMD build (CDN build)
 if (typeof window !== "undefined" && __GLOBAL__) {
   (window as any).InAppSpy = InAppSpy; // Default export
   (window as any).SFSVCExperimental = SFSVCExperimental; // Named export

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,6 +9,9 @@ export default defineConfig([
     splitting: false,
     clean: true,
     outDir: "dist",
+    define: {
+      __GLOBAL__: "false", // No global attachment in module builds
+    },
   },
   {
     entry: ["src/index.ts"],
@@ -19,5 +22,8 @@ export default defineConfig([
     splitting: false,
     clean: true,
     minify: true,
+    define: {
+      __GLOBAL__: "true", // Enable global attachment in the UMD build
+    },
   },
 ]);


### PR DESCRIPTION
For commonJS + ESmodules removes InAppSpy from the window (should be using imports/requres instead). Rely on `window` for UMD CDNs.