### PR TITLE
Fix iOS Arc from being included in SFSVC detection (false positive)

### DIFF
--- a/src/detectIOSArc.ts
+++ b/src/detectIOSArc.ts
@@ -1,0 +1,3 @@
+export const getIsIOSArc = () => {
+  return "observeHeadAdded" in window && !!window.observeHeadAdded;
+};

--- a/src/detectPWA.ts
+++ b/src/detectPWA.ts
@@ -1,0 +1,3 @@
+export const getIsPWA = () => {
+  return "clearAppBadge" in (window?.navigator || {});
+};

--- a/src/detectSFSVC.ts
+++ b/src/detectSFSVC.ts
@@ -1,3 +1,5 @@
+import { getIsIOSArc } from "./detectIOSArc";
+import { getIsPWA } from "./detectPWA";
 import { getIsSafariPrivate } from "./detectSafariPrivate";
 import { getIsTelegram } from "./detectTelegram";
 import {
@@ -60,23 +62,19 @@ export const getSFSVCExperimental = async ({
   const ua = getUA();
 
   // Early exit checks
-  if (!ua) return false; // No user agent
+  if (!ua) return false;
   if (!isiOS(ua)) return false; // iPad or iPhone
-  if (!getIsSafariUA(ua)) return false; // Safari
-  if ("clearAppBadge" in (window?.navigator || {})) return false; // PWAs
+  if (!getIsSafariUA(ua)) return false;
+  if (getIsPWA()) return false;
   if (getIsTelegram()) return false;
-  // TODO: Need to do Arc detection
+  if (getIsIOSArc()) return false;
 
   // Targeted versions of Safari that this check is valid for
   const version = getSafariVersion(ua);
   if (compare(version, minSafariVersion) < 0) return false;
 
   // User specified max version
-  if (
-    maxVersion !== undefined &&
-    (compare(maxVersion, minSafariVersion) < 0 ||
-      compare(version, maxVersion) > 0)
-  )
+  if (maxVersion !== undefined && compare(version, maxVersion) > 0)
     return false;
 
   // Detection for Safari 26.4+

--- a/src/tests/inappspy.test.ts
+++ b/src/tests/inappspy.test.ts
@@ -183,7 +183,8 @@ describe("InAppSpy", () => {
       const isSafariUA = getIsSafariUA(userAgent);
       expect(isSafariUA).toBe(
         ["SAFARI", "PWA_SAFARI", "PRIVATE_SAFARI", "SFSVC"].includes(app) ||
-          (app === "TELEGRAM" && deviceName === "IPHONE") // odd case where UA is unchanged for telegram
+          // odd cases where UA is indistinguishable from Safari
+          (["ARC", "TELEGRAM"].includes(app) && deviceName === "IPHONE")
       );
     });
   });

--- a/src/tests/mobile.ts
+++ b/src/tests/mobile.ts
@@ -235,6 +235,19 @@ export const MOBILE: DeviceObj = {
           },
         },
       ],
+      ARC: [
+        {
+          useragents: [
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Mobile/15E148 Safari/604.1",
+          ],
+          window: {
+            navigator: { storage: { getDirectory: () => {} } },
+            browser: {}, // way to detect in 26.4+
+            observeHeadAdded: {}, // way to detect iOS Arc (is a function but just checking for presence here)
+            ...appleTouchWindow.window,
+          },
+        },
+      ],
     },
   },
   SONY: {


### PR DESCRIPTION
Related #37 

Excludes Arc browser via `observeHeadAdded` being attached to the window