### PR TITLE
Add Reddit in-app browser detection (Android only)

### DIFF
--- a/.changeset/reddit-android-detection.md
+++ b/.changeset/reddit-android-detection.md
@@ -1,0 +1,5 @@
+---
+"inapp-spy": patch
+---
+
+Add Reddit in-app browser detection (Android only)

--- a/README.md
+++ b/README.md
@@ -43,11 +43,14 @@ Machine-friendly key
 
 All except `telegram` use UA detection strategies - server or client friendly. `telegram` can only be detected client-side
 
+> `reddit` is Android only. On iOS, Reddit opens external links in an `SFSafariViewController` and does not add an app token to the user agent, so it is indistinguishable from Safari by UA. Use `SFSVCExperimental` to catch that case.
+
 - `facebook`
 - `gsa`
 - `instagram`
 - `line`
 - `linkedin`
+- `reddit`
 - `snapchat`
 - `telegram`
 - `threads`

--- a/src/regexAppName.ts
+++ b/src/regexAppName.ts
@@ -49,6 +49,10 @@ export const appNameRegExps = {
     regex: /\b(WAiOS|WA4A)\//i,
     name: "WhatsApp",
   },
+  reddit: {
+    regex: /\bReddit\//i,
+    name: "Reddit",
+  },
 } as const;
 
 export const appKeysDetectByUA = Object.keys(

--- a/src/tests/mobile.ts
+++ b/src/tests/mobile.ts
@@ -341,6 +341,13 @@ export const MOBILE: DeviceObj = {
           ],
         },
       ],
+      REDDIT: [
+        {
+          useragents: [
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/AP2A.240905.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/130.0.6723.58 Mobile Safari/537.36 Reddit/Version 2024.41.0/Build 2102450/Android 14",
+          ],
+        },
+      ],
     },
     not_inapp: {
       PUFFIN: [
@@ -479,6 +486,13 @@ export const MOBILE: DeviceObj = {
         {
           useragents: [
             "Mozilla/5.0 (Linux; Android 6.0.1; Redmi Note 3 Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 Instagram 10.21.0 Android (23/6.0.1; 480dpi; 1080x1920; Xiaomi; Redmi Note 3; kate; qcom; zh_TW)",
+          ],
+        },
+      ],
+      REDDIT: [
+        {
+          useragents: [
+            "Mozilla/5.0 (Linux; Android 15; 23129RN51X Build/AP3A.240905.015.A2; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/148.0.7778.215 Mobile Safari/537.36 Reddit/Version 2026.23.0/Build 2623040/Android 15",
           ],
         },
       ],


### PR DESCRIPTION
## Summary

<img width="768" height="1024" alt="image" src="https://github.com/user-attachments/assets/fb04b1cc-2af6-4377-892d-cf202f0b6f6c" />


Adds detection for the **Reddit** in-app browser.

On Android, the Reddit app's in-app webview appends a `Reddit/...` token to the user agent (e.g. `... Mobile Safari/537.36 Reddit/Version 2026.23.0/Build 2623040/Android 15`), so it can be detected reliably via UA on both the client and server.

```
appKey: "reddit"
appName: "Reddit"
```

## iOS is intentionally not supported

On iOS, Reddit opens external links in an **`SFSafariViewController`** and does **not** add any app identifier to the user agent — the UA is indistinguishable from regular mobile Safari. Because there is nothing in the UA (or any reliable window signal unique to Reddit) to key off of, UA-based detection is impossible on iOS. The existing `SFSVCExperimental` helper is the recommended way to catch that case.

This limitation is documented in the README next to the `reddit` appKey.

## Changes

- `src/regexAppName.ts`: add `reddit` regex (`/\bReddit\//i`) + name
- `src/tests/mobile.ts`: add Android Reddit UA test cases (Redmi + Pixel)
- `README.md`: add `reddit` to the appKey list and document the Android-only / iOS SFSVC limitation
- changeset (patch)

## Test plan

- [x] `pnpm test` — all suites pass (24/24), Reddit UAs detected as `inapp`
- [x] `pnpm build` — builds clean
- [x] Verified plain iOS Safari / SFSVC UAs do **not** false-positive as Reddit

Made with [Cursor](https://cursor.com)